### PR TITLE
Change to using action names from our default action map

### DIFF
--- a/player/interaction_functions/gxdk_pickup.gd
+++ b/player/interaction_functions/gxdk_pickup.gd
@@ -93,7 +93,7 @@ static var _highlighted_bodies: Dictionary[Node3D, HighlightedBody]
 			_editor_mesh_instance.position = detection_offset
 
 ## The action we check when grabbing things
-@export var grab_action: String = "grab"
+@export var grab_action: String = "grip"
 
 ## If false we need to continously hold our grab button, if true we toggle
 ## Note: with keyboard entry toggle is enforced

--- a/player/teleport_function/gxdk_teleport.gd
+++ b/player/teleport_function/gxdk_teleport.gd
@@ -54,14 +54,14 @@ signal teleport_done
 @export_group("Input")
 
 ## Action map input for out teleport function.
-@export var teleport_action: String = "teleport"
+@export var teleport_action: String = "primary_click"
 
 ## Do we need to hold our button to teleport,
 ## or do we toggle it?
 @export_enum("Toggle", "Hold") var teleport_action_mode: int = 0
 
 ## Action map input for rotating our target
-@export var rotate_action: String = "move.x"
+@export var rotate_action: String = "primary.x"
 
 ## Maximum angle between target surface and player
 @export_range(0.0, 1400.0, 1.0, "radians_as_degrees", "suffix:°/s") var max_rotation_speed: float = deg_to_rad(360.0)

--- a/prefabs/gxdk_character_body_3d.tscn
+++ b/prefabs/gxdk_character_body_3d.tscn
@@ -32,12 +32,12 @@ layers = 2
 [node name="LeftCollisionHand" type="RigidBody3D" parent="XROrigin3D" unique_id=360497191]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5, 1, -0.5)
 script = ExtResource("4_tec0s")
-grip_action = "grab"
+grip_action = "grip"
 metadata/_custom_type_script = "uid://xrt2ebmt58c"
 
 [node name="RightCollisionHand" type="RigidBody3D" parent="XROrigin3D" unique_id=709012286]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 1, -0.5)
 script = ExtResource("4_tec0s")
 hand = 1
-grip_action = "grab"
+grip_action = "grip"
 metadata/_custom_type_script = "uid://xrt2ebmt58c"


### PR DESCRIPTION
While I had some of the default set on various scripts, a few were using the alternative names I was using on the demo.

OpenXR action maps are expected to use names that make sense for the games, so a rebinding UI presented to the user provide sensible names. The demo was originally designed to reflect this.

As Godot users will start a new project with the default action map, having the toolkit default to alternative names will just lead to confusion.