### PR TITLE
Change actions to use default action names

### DIFF
--- a/openxr_action_map.tres
+++ b/openxr_action_map.tres
@@ -1,8 +1,8 @@
 [gd_resource type="OpenXRActionMap" format=3 uid="uid://d2gs06i31m6au"]
 
 [sub_resource type="OpenXRAction" id="OpenXRAction_pbs6g"]
-resource_name = "move"
-localized_name = "Move character"
+resource_name = "primary"
+localized_name = "Primary joystick/thumbstick/trackpad"
 action_type = 2
 toplevel_paths = PackedStringArray("/user/hand/left", "/user/hand/right")
 
@@ -19,8 +19,8 @@ action_type = 4
 toplevel_paths = PackedStringArray("/user/hand/left", "/user/hand/right")
 
 [sub_resource type="OpenXRAction" id="OpenXRAction_36iii"]
-resource_name = "grab"
-localized_name = "Grab object"
+resource_name = "grip"
+localized_name = "Grip"
 toplevel_paths = PackedStringArray("/user/hand/left", "/user/hand/right")
 
 [sub_resource type="OpenXRAction" id="OpenXRAction_6ivru"]
@@ -29,8 +29,8 @@ localized_name = "Trigger"
 toplevel_paths = PackedStringArray("/user/hand/left", "/user/hand/right")
 
 [sub_resource type="OpenXRAction" id="OpenXRAction_vfhwq"]
-resource_name = "teleport"
-localized_name = "Enable teleport"
+resource_name = "primary_click"
+localized_name = "Primary joystick/thumbstick/trackpad click"
 action_type = 0
 toplevel_paths = PackedStringArray("/user/hand/left", "/user/hand/right")
 

--- a/stages/climbing_stage/climbing_stage.tscn
+++ b/stages/climbing_stage/climbing_stage.tscn
@@ -19,7 +19,7 @@ collision_mask = 3
 
 [node name="TurnMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/LeftCollisionHand" index="0" unique_id=2081252770]
 script = ExtResource("3_7aybs")
-movement_action = "move"
+movement_action = "primary"
 forward_movement_speed = 0.0
 metadata/_custom_type_script = "uid://xrt2ebknph2"
 
@@ -33,7 +33,7 @@ collision_mask = 3
 
 [node name="StrafeMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/RightCollisionHand" index="0" unique_id=46491692]
 script = ExtResource("3_7aybs")
-movement_action = "move"
+movement_action = "primary"
 rotation_speed = 0.0
 strafe_movement_speed = 3.0
 metadata/_custom_type_script = "uid://xrt2ebknph2"

--- a/stages/menu_stage/menu_stage.tscn
+++ b/stages/menu_stage/menu_stage.tscn
@@ -35,13 +35,13 @@ script = ExtResource("1_qi4g2")
 
 [node name="TurnMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/LeftCollisionHand" parent_id_path=PackedInt32Array(795871005, 360497191) index="0" unique_id=1896713981]
 script = ExtResource("4_n0kdf")
-movement_action = "move"
+movement_action = "primary"
 forward_movement_speed = 0.0
 movement_acceleration = 0.0
 
 [node name="StrafeMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/RightCollisionHand" parent_id_path=PackedInt32Array(795871005, 709012286) index="0" unique_id=1832545822]
 script = ExtResource("4_n0kdf")
-movement_action = "move"
+movement_action = "primary"
 rotation_speed = 0.0
 strafe_movement_speed = 2.5
 

--- a/stages/movement_stage/movement_stage.tscn
+++ b/stages/movement_stage/movement_stage.tscn
@@ -14,13 +14,13 @@ script = ExtResource("1_bqu4o")
 
 [node name="TurnMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/LeftCollisionHand" parent_id_path=PackedInt32Array(795871005, 360497191) index="2" unique_id=1945289616]
 script = ExtResource("4_30jb3")
-movement_action = "move"
+movement_action = "primary"
 forward_movement_speed = 0.0
 metadata/_custom_type_script = "uid://xrt2ebknph2"
 
 [node name="StrafeMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/RightCollisionHand" parent_id_path=PackedInt32Array(795871005, 709012286) index="2" unique_id=1533277168]
 script = ExtResource("4_30jb3")
-movement_action = "move"
+movement_action = "primary"
 rotation_speed = 0.0
 strafe_movement_speed = 3.0
 metadata/_custom_type_script = "uid://xrt2ebknph2"

--- a/stages/object_interaction_stage/object_interaction_stage.tscn
+++ b/stages/object_interaction_stage/object_interaction_stage.tscn
@@ -20,7 +20,7 @@ metadata/_custom_type_script = "uid://xrt23qrb4js"
 
 [node name="TurnMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/LeftCollisionHand" parent_id_path=PackedInt32Array(795871005, 360497191) index="3" unique_id=846136560]
 script = ExtResource("5_5hmy8")
-movement_action = "move"
+movement_action = "primary"
 metadata/_custom_type_script = "uid://xrt2ebknph2"
 
 [node name="GXDKPickup" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/RightCollisionHand" parent_id_path=PackedInt32Array(795871005, 709012286) index="2" unique_id=2103181334]
@@ -30,7 +30,7 @@ metadata/_custom_type_script = "uid://xrt23qrb4js"
 
 [node name="StrafeMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/RightCollisionHand" parent_id_path=PackedInt32Array(795871005, 709012286) index="3" unique_id=307544332]
 script = ExtResource("5_5hmy8")
-movement_action = "move"
+movement_action = "primary"
 rotation_speed = 0.0
 strafe_movement_speed = 3.0
 metadata/_custom_type_script = "uid://xrt2ebknph2"

--- a/stages/teleport_stage/teleport_scene.tscn
+++ b/stages/teleport_stage/teleport_scene.tscn
@@ -12,7 +12,7 @@ script = ExtResource("1_7f1qv")
 
 [node name="GXDKCharacterBody3D" parent="." unique_id=795871005 instance=ExtResource("3_gn4u1")]
 
-[node name="GXDKTeleport" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/LeftCollisionHand" parent_id_path=PackedInt32Array(795871005, 360497191) index="2" unique_id=2011988880]
+[node name="GXDKTeleport" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/LeftCollisionHand" parent_id_path=PackedInt32Array(795871005, 360497191) index="0" unique_id=2011988880]
 transform = Transform3D(0.99500257, -0.0035018958, 0.09978712, -0.003500683, 0.99754673, 0.069914035, -0.09978719, -0.069914, 0.99254906, -0.0011376105, -0.0007457088, -0.022510625)
 script = ExtResource("4_xtqrp")
 bone_name = "LeftMiddleMetacarpal"

--- a/stages/test_stage/test_stage.tscn
+++ b/stages/test_stage/test_stage.tscn
@@ -84,7 +84,7 @@ transform = Transform3D(1, 0, 0, 0, 0.99999994, 0, 0, 0, 0.99999994, -0.5, 1, -0
 
 [node name="TurnMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/LeftCollisionHand" index="0" unique_id=1416942326]
 script = ExtResource("3_7f0s7")
-movement_action = "move"
+movement_action = "primary"
 forward_movement_speed = 0.0
 movement_acceleration = 0.0
 
@@ -110,7 +110,7 @@ metadata/_custom_type_script = "uid://xrt2apc5enq"
 
 [node name="StrafeMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/RightCollisionHand" parent_id_path=PackedInt32Array(1387237929, 709012286) index="0" unique_id=424588044]
 script = ExtResource("3_7f0s7")
-movement_action = "move"
+movement_action = "primary"
 rotation_speed = 0.0
 strafe_movement_speed = 2.5
 

--- a/stages/ui_stage/ui_stage.tscn
+++ b/stages/ui_stage/ui_stage.tscn
@@ -23,7 +23,7 @@ metadata/_custom_type_script = "uid://xrt2cl3xuef"
 
 [node name="TurnMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/LeftCollisionHand" parent_id_path=PackedInt32Array(795871005, 360497191) index="1" unique_id=1797746029]
 script = ExtResource("5_s2wix")
-movement_action = "move"
+movement_action = "primary"
 forward_movement_speed = 0.0
 metadata/_custom_type_script = "uid://xrt2ebknph2"
 
@@ -36,7 +36,7 @@ metadata/_custom_type_script = "uid://xrt2cl3xuef"
 
 [node name="StrafeMovement" type="Node3D" parent="GXDKCharacterBody3D/XROrigin3D/RightCollisionHand" parent_id_path=PackedInt32Array(795871005, 709012286) index="1" unique_id=1314741855]
 script = ExtResource("5_s2wix")
-movement_action = "move"
+movement_action = "primary"
 rotation_speed = 0.0
 strafe_movement_speed = 3.0
 metadata/_custom_type_script = "uid://xrt2ebknph2"


### PR DESCRIPTION
OpenXR action maps are expected to use names that make sense for the games, so a rebinding UI presented to the user provide sensible names.

The demo was originally designed to reflect this but it leads to easy confusion and a high likelihood of nodes from the toolkit defaulting to the alternative names.

I've decided to stick to the default action names BUT will limit the demos action map to just the actions we actually use. I decent middleground.